### PR TITLE
Change the configuration of Zappr to comply with the Rules of Play

### DIFF
--- a/.zappr.yaml
+++ b/.zappr.yaml
@@ -1,2 +1,2 @@
 X-Zalando-Team: automata
-X-Zalando-Type: code
+X-Zalando-Type: tools

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.5] - 2019-05-16
+
+### Fixed
+
+ - Change the configuration of [Zappr](.zappr.yaml) to comply with the [Rules of Play].
+ 
+[Rules of Play]: https://opensource.zalando.com/docs/releasing/index/#be-compliant
+
 ## [1.2.4][] - 2019-05-10
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "zelt"
-version = "1.2.4"
+version = "1.2.5"
 description = "Zalando end-to-end load tester"
 authors = [
     "Brian Maher <brian.maher@zalando.de>",


### PR DESCRIPTION
Signed-off-by: Oliwia Zaremba <oliwia.zaremba@zalando.de>

## Description
Refers to #2406 in Automata internal backlog.

Changing the type of this repository from `code` to `tools` so that we can keep using Zincr and the repo can remain compliant. Zelt doesn't require to be of type `code` because - as far as its internal usage is concerned - it was never deployed to a cluster that required this characteristic.

## Types of Changes
- Configuration change

## Review

_Reviewers' checklist:_

- If this PR _implements_ new flows or _changes_ existing ones, are there
  **good tests** for these flows?
  If this PR rather _removes_ flows, are the obsolete tests removed as well?
- Is the documentation still up-to-date and exhaustive? This covers both
  _technical_ (in source files) and _functional_ (under `docs/`) documentation.
- Is the **changelog** updated?
- Does the **new version number** correspond to the actual changes from this PR?
  In doubt, refer to https://semver.org.

