### PR TITLE
Moving Sphinx dependencies back out of dev.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.10][] - 2019-05-21
+
+### Fixed
+
+  - Failing Read The Docs build.
+
 ## [1.2.9][] - 2019-05-21
 
 ### Added
@@ -75,6 +81,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Implemented `-v`/`--version` option to show Zelt version.
   - This changelog.
 
+[1.2.10]: https://github.com/zalando-incubator/zelt/compare/v1.2.9...v1.2.10
 [1.2.9]: https://github.com/zalando-incubator/zelt/compare/v1.2.8...v1.2.9
 [1.2.8]: https://github.com/zalando-incubator/zelt/compare/v1.2.7...v1.2.8
 [1.2.7]: https://github.com/zalando-incubator/zelt/compare/v1.2.6...v1.2.7

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: install
 install:
-	poetry install
+	poetry install -E docs
 
 .PHONY: test
 test:

--- a/poetry.lock
+++ b/poetry.lock
@@ -13,10 +13,10 @@ python-dateutil = ">=2.1.0"
 requests = ">=2.0.0"
 
 [[package]]
-category = "dev"
+category = "main"
 description = "A configurable sidebar-enabled Sphinx theme"
 name = "alabaster"
-optional = false
+optional = true
 python-versions = "*"
 version = "0.7.12"
 
@@ -67,10 +67,10 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 version = "19.1.0"
 
 [[package]]
-category = "dev"
+category = "main"
 description = "Internationalization utilities"
 name = "babel"
-optional = false
+optional = true
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 version = "2.6.0"
 
@@ -162,7 +162,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 version = "7.0"
 
 [[package]]
-category = "dev"
+category = "main"
 description = "Cross-platform colored terminal text."
 name = "colorama"
 optional = false
@@ -295,10 +295,10 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 version = "2.8"
 
 [[package]]
-category = "dev"
+category = "main"
 description = "Getting image size from png/jpeg/jpeg2000/gif file"
 name = "imagesize"
-optional = false
+optional = true
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 version = "1.1.0"
 
@@ -424,10 +424,10 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 version = "3.0.1"
 
 [[package]]
-category = "dev"
+category = "main"
 description = "Core utilities for Python packages"
 name = "packaging"
-optional = false
+optional = true
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 version = "19.0"
 
@@ -499,10 +499,10 @@ python-versions = "*"
 version = "2.19"
 
 [[package]]
-category = "dev"
+category = "main"
 description = "Pygments is a syntax highlighting package written in Python."
 name = "pygments"
-optional = false
+optional = true
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 version = "2.4.0"
 
@@ -529,10 +529,10 @@ isort = ">=4.2.5,<5"
 mccabe = ">=0.6,<0.7"
 
 [[package]]
-category = "dev"
+category = "main"
 description = "Python parsing module"
 name = "pyparsing"
-optional = false
+optional = true
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 version = "2.4.0"
 
@@ -596,10 +596,10 @@ version = "2.8.0"
 six = ">=1.5"
 
 [[package]]
-category = "dev"
+category = "main"
 description = "World timezone definitions, modern and historical"
 name = "pytz"
-optional = false
+optional = true
 python-versions = "*"
 version = "2019.1"
 
@@ -684,18 +684,18 @@ python-versions = ">=2.6, !=3.0.*, !=3.1.*"
 version = "1.12.0"
 
 [[package]]
-category = "dev"
+category = "main"
 description = "This package provides 16 stemmer algorithms (15 + Poerter English stemmer) generated from Snowball algorithms."
 name = "snowballstemmer"
-optional = false
+optional = true
 python-versions = "*"
 version = "1.2.1"
 
 [[package]]
-category = "dev"
+category = "main"
 description = "Python documentation generator"
 name = "sphinx"
-optional = false
+optional = true
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 version = "1.8.5"
 
@@ -715,10 +715,10 @@ snowballstemmer = ">=1.1"
 sphinxcontrib-websupport = "*"
 
 [[package]]
-category = "dev"
+category = "main"
 description = "Type hints (PEP 484) support for the Sphinx autodoc extension"
 name = "sphinx-autodoc-typehints"
-optional = false
+optional = true
 python-versions = "!=3.5.0, !=3.5.1"
 version = "1.6.0"
 
@@ -726,10 +726,10 @@ version = "1.6.0"
 Sphinx = ">=1.7"
 
 [[package]]
-category = "dev"
+category = "main"
 description = "A Sphinx extension for linking to your project's issue tracker"
 name = "sphinx-issues"
-optional = false
+optional = true
 python-versions = "*"
 version = "1.2.0"
 
@@ -737,10 +737,10 @@ version = "1.2.0"
 sphinx = "*"
 
 [[package]]
-category = "dev"
+category = "main"
 description = "Sphinx API for Web Apps"
 name = "sphinxcontrib-websupport"
-optional = false
+optional = true
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 version = "1.1.2"
 
@@ -820,8 +820,11 @@ optional = false
 python-versions = "*"
 version = "1.11.1"
 
+[extras]
+docs = ["sphinx", "sphinx-autodoc-typehints", "sphinx-issues"]
+
 [metadata]
-content-hash = "9bc4d8b90a01537aeffa780f6893646ee17d4a53753b343893ac84c8c02a652d"
+content-hash = "629df07915243dcfa0e6d4774f0c532770368fe1269396fd2ea8855a811dd150"
 python-versions = "^3.6"
 
 [metadata.hashes]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,14 +31,18 @@ tenacity = "^5.0"
 docopt = "^0.6.2"
 pyyaml = "^5.1"
 
+sphinx = { version = "^1.8", optional = true }
+sphinx-autodoc-typehints = { version = "^1.6", optional = true }
+sphinx-issues = { version = "^1.2", optional = true }
+
+[tool.poetry.extras]
+docs = ["sphinx", "sphinx-autodoc-typehints", "sphinx-issues"]
+
 [tool.poetry.dev-dependencies]
 pytest-cov = "^2.6"
 pytest = "^4.3"
 pylint = "^2.3"
 pytest-watch = "^4.2"
-sphinx = "^1.8"
-sphinx-autodoc-typehints = "^1.6"
-sphinx-issues = "^1.2"
 
 [tool.poetry.scripts]
 zelt = "main:cli"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "zelt"
-version = "1.2.9"
+version = "1.2.10"
 description = "Zalando end-to-end load tester"
 authors = [
     "Brian Maher <brian.maher@zalando.de>",


### PR DESCRIPTION
Attempt to fix failing docs build.

Part of #5.

## Description

It seems like Read The Docs' [build fails](https://readthedocs.org/projects/zelt/builds/9096352/) if they there.
Copied the full configuration from [Transformer](https://github.com/zalando-incubator/Transformer/blob/master/pyproject.toml#L36).

## Types of Changes

_What types of changes does your code introduce? Keep the ones that apply:_

- Configuration change

## Review

_Reviewers' checklist:_

- If this PR _implements_ new flows or _changes_ existing ones, are there
  **good tests** for these flows?
  If this PR rather _removes_ flows, are the obsolete tests removed as well?
- Is the documentation still up-to-date and exhaustive? This covers both
  _technical_ (in source files) and _functional_ (under `docs/`) documentation.
- Is the **changelog** updated?
- Does the **new version number** correspond to the actual changes from this PR?
  In doubt, refer to https://semver.org.
