### PR TITLE
Ignore version checking if building latest tag.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ language: python
 python:
 - '3.6'
 - '3.7'
+# Don't build tags.
+branches:
+  except:
+    - /^v\d+\.\d+(\.\d+)?(-\S*)?$/
 install:
 - pip install --upgrade pip==18.1
 - pip install poetry codacy-coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.12][] - 2019-05-22
+
+### Fixed
+
+  - Don't build tag branches in CI.
+
 ## [1.2.11][] - 2019-05-21
 
 ### Added
@@ -93,6 +99,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Implemented `-v`/`--version` option to show Zelt version.
   - This changelog.
 
+[1.2.12]: https://github.com/zalando-incubator/zelt/compare/v1.2.11...v1.2.12
 [1.2.11]: https://github.com/zalando-incubator/zelt/compare/v1.2.10...v1.2.11
 [1.2.10]: https://github.com/zalando-incubator/zelt/compare/v1.2.9...v1.2.10
 [1.2.9]: https://github.com/zalando-incubator/zelt/compare/v1.2.8...v1.2.9

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "zelt"
-version = "1.2.11"
+version = "1.2.12"
 description = "Zalando end-to-end load tester"
 authors = [
     "Brian Maher <brian.maher@zalando.de>",


### PR DESCRIPTION
Part of #6.

## Description

This PR fixes a bug where Travis CI builds tags after merges to master, resulting in a failure in the version checking script (versions matched between master and tag).

Instructed Travis to ignore all branches matching a regex representing tags `/^v\d+\.\d+(\.\d+)?(-\S*)?$/`.

## Types of Changes

_What types of changes does your code introduce? Keep the ones that apply:_

- Configuration change

## Review

_Reviewers' checklist:_

- If this PR _implements_ new flows or _changes_ existing ones, are there
  **good tests** for these flows?
  If this PR rather _removes_ flows, are the obsolete tests removed as well?
- Is the documentation still up-to-date and exhaustive? This covers both
  _technical_ (in source files) and _functional_ (under `docs/`) documentation.
- Is the **changelog** updated?
- Does the **new version number** correspond to the actual changes from this PR?
  In doubt, refer to https://semver.org.

## After this PR

Any follow-up action necessary?
